### PR TITLE
Refactoring to simplify loop

### DIFF
--- a/FileFormats/Gff/Gff_Friendly.cpp
+++ b/FileFormats/Gff/Gff_Friendly.cpp
@@ -86,11 +86,10 @@ GffList::GffList(Raw::GffField const& rawField, Raw::Gff const& rawGff)
 
     Raw::GffField::Type_List list = rawGff.ConstructList(rawField);
 
-    for (std::size_t i = 0; i < list.m_Elements.size(); ++i)
+    for (std::uint32_t offsetIntoStructArray : list.m_Elements)
     {
-        std::uint32_t offsetIntoStructArray = list.m_Elements[i];
         ASSERT(offsetIntoStructArray < rawGff.m_Structs.size());
-        m_Structs.emplace_back(GffStruct(rawGff.m_Structs[offsetIntoStructArray], rawGff));
+        m_Structs.emplace_back(rawGff.m_Structs[offsetIntoStructArray], rawGff);
     }
 }
 


### PR DESCRIPTION
Use a range-based for loop to eliminate risk of fence-post errors (by design).
For 'emplace_back', provide constructor arguments directly, rather than constructing a temporary to move.