### PR TITLE
Avoid a needless copy

### DIFF
--- a/FileFormats/Gff/Gff_Raw.cpp
+++ b/FileFormats/Gff/Gff_Raw.cpp
@@ -176,7 +176,7 @@ GffField::Type_CExoLocString Gff::ConstructCExoLocString(GffField const& field) 
         substring.m_String = std::string(reinterpret_cast<char const*>(ptr), substringLength);
         ptr += substringLength;
 
-        locString.m_SubStrings.emplace_back(substring);
+        locString.m_SubStrings.emplace_back(std::move(substring));
     }
 
     return locString;


### PR DESCRIPTION
Efficiency obsessed tweak, slightly less-clean code.
'emplace_back' will make a copy when passed an lvalue, so 'move' the substring to emplace using the (implicitly generated) move constructor for 'substring'.  This potential optimization is pointless though, if we know that the substring length will always be less than the small string optimization buffer size - possibly worth a comment if that is a deliberate design choice (I don't know realistic data to know if this is an issue).