### PR TITLE
2da inconsistency fixes

### DIFF
--- a/FileFormats/2da/2da_Friendly.cpp
+++ b/FileFormats/2da/2da_Friendly.cpp
@@ -115,15 +115,26 @@ TwoDA::TwoDA(Raw::TwoDA const& raw2da)
     // Line 3 has all the columns.
     ASSERT(raw2da.m_Lines.size() >= 3);
 
-    // Iterate over all of the column names and set up the map.
-    for (std::size_t i = 0; i < raw2da.m_Lines[2].m_Tokens.size(); ++i)
+    std::size_t start_line = 1;
+    // Find first nonempty row (it will contain column labels)
+    for (std::size_t i = start_line; i < raw2da.m_Lines.size(); ++i)
     {
-        std::string const& token = raw2da.m_Lines[2].m_Tokens[i];
+        if (raw2da.m_Lines[i].m_Tokens.size() > 0)
+        {
+            start_line = i;
+            break;
+        }
+    }
+
+    // Iterate over all of the column names and set up the map.
+    for (std::size_t i = 0; i < raw2da.m_Lines[start_line].m_Tokens.size(); ++i)
+    {
+        std::string const& token = raw2da.m_Lines[start_line].m_Tokens[i];
         m_ColumnNames[token] = i;
     }
 
     // Iterate over all of the entries and set them up.
-    for (std::size_t i = 3; i < raw2da.m_Lines.size(); ++i)
+    for (std::size_t i = start_line + 1; i < raw2da.m_Lines.size(); ++i)
     {
         std::vector<TwoDAEntry> entries;
         std::vector<Raw::TwoDAToken> const& tokens = raw2da.m_Lines[i].m_Tokens;

--- a/FileFormats/2da/2da_Friendly.cpp
+++ b/FileFormats/2da/2da_Friendly.cpp
@@ -134,9 +134,19 @@ TwoDA::TwoDA(Raw::TwoDA const& raw2da)
             continue;
         }
 
-        // We store the row ID - this isn't necessarily to be used by the user,
-        // but could store funky stuff that we might want to access.
-        std::uint32_t rowId = std::stoul(tokens[0]);
+        // Some 2da files have more 1 empty rows, resulting in i=3 => row where
+        // first token is column name
+        std::uint32_t rowId;
+        try
+        {
+            // We store the row ID - this isn't necessarily to be used by the user,
+            // but could store funky stuff that we might want to access.
+            rowId = std::stoul(tokens[0]);
+        }
+        catch (std::invalid_argument& e)
+        {
+            continue;
+        }
 
         // Skip the first token (which is the row number) when setting this up.
         for (std::size_t j = 1; j < m_ColumnNames.size() + 1; ++j)

--- a/FileFormats/2da/2da_Raw.cpp
+++ b/FileFormats/2da/2da_Raw.cpp
@@ -233,8 +233,12 @@ bool TwoDA::ConstructInternal(std::byte const* bytes, std::size_t bytesCount)
     ASSERT(m_Lines.size() >= 3);
 
     ASSERT(m_Lines[0].m_Tokens.size() == 2);
-    ASSERT(m_Lines[0].m_Tokens[0].size() == 3);
-    ASSERT(m_Lines[0].m_Tokens[1].size() == 4);
+    // Add trimming to asserted strings, since some 2da files
+    // seem to be inconsisten
+    std::string first = m_Lines[0].m_Tokens[0];
+    std::string second = m_Lines[0].m_Tokens[1];
+    ASSERT(first.erase(first.find_last_not_of(" \n\r\t") + 1).size() == 3);
+    ASSERT(second.erase(second.find_last_not_of(" \n\r\t") + 1).size() == 4);
 
     if (std::memcmp(m_Lines[0].m_Tokens[0].c_str(), "2DA", 3) != 0 ||
         std::memcmp(m_Lines[0].m_Tokens[1].c_str(), "V2.0", 4) != 0)


### PR DESCRIPTION
Some 2da files (found xpbaseconst.2da, cloakmodel.2da) are inconsistent in header's file version and number of empty rows.