### PR TITLE
fix for compilation in linux

### DIFF
--- a/Examples/Example_Gff.cpp
+++ b/Examples/Example_Gff.cpp
@@ -1,6 +1,7 @@
 #include "FileFormats/Gff.hpp"
 #include "Utility/Assert.hpp"
 
+#include <cstring>
 #include <cinttypes>
 
 namespace {

--- a/Tools/Tool_GeneratePlaceableBlueprints.cpp
+++ b/Tools/Tool_GeneratePlaceableBlueprints.cpp
@@ -2,6 +2,7 @@
 #include "FileFormats/Gff.hpp"
 
 #include <set>
+#include <cstring>
 
 #if OS_WINDOWS
     #include "Windows.h"


### PR DESCRIPTION
During compilation on Ubunt 19.10, an error occurred "error: no member named 'memcpy' in namespace 'std'".
These are fixes.